### PR TITLE
fix: add offset to scrollToHeading for fixed headers

### DIFF
--- a/src/app/docs/marquee/marqueeText.tsx
+++ b/src/app/docs/marquee/marqueeText.tsx
@@ -14,7 +14,7 @@ const MarqueeText = () => {
   return (
     <div className="w-full font-sans overflow-hidden">
       <LinearLoop
-        marqueeText="Hello there ! how's going ? welcome to seraui i hope you loike all the desigen componnet"
+        marqueeText="Hello there! How’s it going? Welcome to Seraui. Hope you like all the design components"
         speed={1}
         direction="left"
         interactive={true}

--- a/src/hooks/use-table-of-contents.ts
+++ b/src/hooks/use-table-of-contents.ts
@@ -115,15 +115,14 @@ export function useTableOfContents() {
   }, [toc, activeId]);
 
   // Function to scroll to a heading
-  const scrollToHeading = (id: string) => {
-    const element = document.getElementById(id);
-    if (element) {
-      element.scrollIntoView({
-        behavior: "smooth",
-        block: "start",
-      });
-    }
-  };
+  const scrollToHeading = (id: string, offset: number = 88) => {
+  const element = document.getElementById(id);
+  if (element) {
+    const y = element.getBoundingClientRect().top + window.scrollY - offset;
+    window.scrollTo({ top: y, behavior: "smooth" });
+  }
+};
+
 
   return {
     toc,


### PR DESCRIPTION
margueeText: spellcheck. fix: correct spelling and grammar in welcome message

scrollToHeading does not account for fixed headers, headings hidden after navigation

Description:
When using the scrollToHeading function, clicking a menu link navigates to the correct section, but the heading is hidden under the fixed header.

Steps to reproduce:

Set up a fixed header in the layout.

Use a menu link that calls scrollToHeading.

Observe that the section is obscured by the header.

Expected behavior:
The heading should be visible below the fixed header after scrolling.

Suggestion:
Update scrollToHeading to account for the header’s height using an offset.

System info:

Browser: [e.g. Chrome 114]