### PR TITLE
fix(spider): remove glow filter to restore line visibility between icons

### DIFF
--- a/src/app/docs/integrations/spider.tsx
+++ b/src/app/docs/integrations/spider.tsx
@@ -194,15 +194,25 @@ const IconGrid = () => {
                 height={svgSize}
                 className="absolute top-0 left-0"
             >
-                <defs>
-                    <filter id="glow">
-                        <feGaussianBlur stdDeviation="2" result="coloredBlur" />
-                        <feMerge>
-                            <feMergeNode in="coloredBlur" />
-                            <feMergeNode in="SourceGraphic" />
-                        </feMerge>
-                    </filter>
-                </defs>
+
+            {/* ------------------------------------------------------------------------------------ */}
+            {/*
+              // The filter definition below causes lines with angles (90°, 0°)—such as
+              // the vertical line that links the hash icon with the first icon and the horizontal line linking the
+              // bottom icons—to become invisible when the glow effect is triggered on hover.
+              // Since the glow effect is visually negligible, it was removed to prevent
+              // these lines from being hidden and to preserve line visibility.*/}
+
+            {/* Filter definition */}
+            {/* <defs>
+                <filter id="glow">
+                  <feGaussianBlur stdDeviation="2" result="coloredBlur" />
+                  <feMerge>
+                    <feMergeNode in="coloredBlur" />
+                    <feMergeNode in="SourceGraphic" />
+                  </feMerge>
+                 </filter>
+              </defs> */}
                 <g>
                     {/* Draw lines between outer icons (the "web") */}
                     {outerIcons.map((icon, i) => {
@@ -230,7 +240,7 @@ const IconGrid = () => {
                                 strokeWidth="1.5"
                                 className="transition-all duration-300 dark:stroke-gray-600"
                                 style={{ opacity: isLineActive ? 0.8 : 0.25 }}
-                                filter={isLineActive ? 'url(#glow)' : 'none'}
+                                // Removed the 'filter' prop due to the glow-related visibility issue
                             />
                         );
                     })}
@@ -257,7 +267,7 @@ const IconGrid = () => {
                                 strokeWidth="1.5"
                                 className="transition-all duration-300 dark:stroke-gray-600"
                                 style={{ opacity: isSpokeActive ? 1 : 0.25 }}
-                                filter={isSpokeActive ? 'url(#glow)' : 'none'}
+                                // Removed the 'filter' prop due to the glow-related visibility issue
                             />
                         );
                     })}


### PR DESCRIPTION
## Bug Fix: Some Invisible Lines in Spider Component Due to line Filter

### Summary
This pull request resolves a rendering issue in the `Spider` component where certain icon connector lines became invisible on hover.

### How I Found the Bug
While customizing the `Spider` component for my own use case, I noticed that **lines at specific angles** (0° and 90°) would disappear when hovered. This led me to investigate the SVG filter definitions applied to those lines.

### Details
- The issue occurred with lines positioned at **cardinal angles**:
  - The **vertical line** from the center to the top icon
  - The **horizontal line** connecting icons at the bottom edge
- On hover, an SVG-based **glow effect** caused these lines to become invisible
- This was due to how filters blend layers when elements are perfectly aligned with pixel boundaries

### Fix
- Removed the SVG `<filter>` that was causing the blending issue
- Eliminated its usage from the affected line components

### Rationale
Since the glow effect added **minimal visual enhancement** and introduced **critical rendering bugs**, it was removed to ensure:
- **Consistent visibility** of all lines
- **Better customization experience** for users adapting the component

 Bug identified through real use  
Cleaner rendering without visual regression  
Better UX when customizing the component