### PR TITLE
fix(docs): adjust Newsletter Signup button size for mobile

### DIFF
--- a/src/app/docs/waitlist/waitlist3.tsx
+++ b/src/app/docs/waitlist/waitlist3.tsx
@@ -91,7 +91,7 @@ const Newsletter = () => {
 
             <button
               type="submit"
-              className="w-full sm:w-auto mt-2 sm:mt-0 px-6 py-3 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 font-semibold rounded-full hover:bg-gray-700 dark:hover:bg-gray-200 transition-colors duration-300 shadow-md transform group-hover:scale-105"
+              className="sm:w-auto px-16 mt-2 sm:mt-0 md:px-6 py-3 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 font-semibold rounded-full hover:bg-gray-700 dark:hover:bg-gray-200 transition-colors duration-300 shadow-md transform group-hover:scale-105"
             >
               Get Notified
             </button>


### PR DESCRIPTION
This PR makes a minor UI adjustment to the newsletter waitlist component.

* The submit button in `waitlist3.tsx` was overlaping outside of the main div mostly because of a confliction of the "w-full" syntax plus the extra margin for mobile. Now it uses a wider default horizontal padding (`px-16`) for improved appearance, while retaining responsive behavior for medium screens (`md:px-6`).

Feel free to suggest any adjustments, I’m happy to make further changes if needed to improve the solution :D.

**Tested in**
- Google Chrome
- Opera GX

# Before 
<img width="397" height="812" alt="image" src="https://github.com/user-attachments/assets/13f65e2e-63a6-4d89-a90f-68fe786a54fa" />

# After
<img width="385" height="669" alt="image" src="https://github.com/user-attachments/assets/b808bf2c-9d8b-4abd-8f39-70c439c14c1c" />
