### PR TITLE
feat: Add Kbd (keyboard key) component 

### DIFF
--- a/src/app/docs/kbd/kbd-view.tsx
+++ b/src/app/docs/kbd/kbd-view.tsx
@@ -1,0 +1,12 @@
+import Kbd from "./kbd";
+
+export default function KbdView() {
+  return (
+    <div className="flex w-full items-center justify-center gap-2 p-8">
+      <Kbd>Ctrl</Kbd>
+      <span className="opacity-60">+</span>
+      <Kbd>C</Kbd>
+    </div>
+  );
+}
+

--- a/src/app/docs/kbd/kbd.tsx
+++ b/src/app/docs/kbd/kbd.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type KbdSize = "sm" | "md" | "lg";
+
+export interface KbdProps extends React.HTMLAttributes<HTMLElement> {
+  size?: KbdSize;
+}
+
+export const Kbd = React.forwardRef<HTMLElement, KbdProps>(function Kbd(
+  { className, size = "md", children, ...props },
+  ref
+) {
+  const sizeClasses: Record<KbdSize, string> = {
+    sm: "text-xs px-1.5 py-0.5",
+    md: "text-sm px-2 py-1",
+    lg: "text-base px-2.5 py-1.5",
+  };
+
+  return (
+    <kbd
+      ref={ref as React.Ref<HTMLElement>}
+      className={cn(
+        "inline-flex items-center rounded border border-slate-200 bg-slate-50 text-slate-800 shadow-sm",
+        "dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200",
+        "font-mono select-none leading-none",
+        sizeClasses[size],
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </kbd>
+  );
+});
+
+Kbd.displayName = "Kbd";
+
+export default Kbd;
+

--- a/src/app/docs/kbd/page.mdx
+++ b/src/app/docs/kbd/page.mdx
@@ -1,0 +1,78 @@
+import { CodeBlock } from "@/components/site/code-block";
+import { ComponentRenderer } from "@/components/site/component-renderer";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from "@/components/site/tabs.tsx";
+import KbdView from "./kbd-view";
+import Kbd from "./kbd";
+import { PropsTable } from "@/components/site/props-table.tsx";
+
+# Kbd
+
+A minimalistic keyboard key component designed with React and Tailwind CSS. Use it to display shortcuts (like Ctrl + C) and keypress hints inline with your content for better usability and accessibility.
+
+<Tabs defaultValue="preview">
+  <TabsList>
+    <TabsTrigger value="preview">Preview</TabsTrigger>
+    <TabsTrigger value="code">Code</TabsTrigger>
+  </TabsList>
+  <TabsContent value="preview">
+    <ComponentRenderer component={<KbdView />} />
+  </TabsContent>
+  <TabsContent value="code">
+    <CodeBlock filePath="src/app/docs/kbd/kbd.tsx" />
+  </TabsContent>
+</Tabs>
+
+## Sizes
+
+<div className="mt-4 flex items-center gap-4">
+  <Kbd size="sm">Esc</Kbd>
+  <Kbd size="md">Esc</Kbd>
+  <Kbd size="lg">Esc</Kbd>
+</div>
+
+
+```tsx
+import Kbd from "./kbd";
+
+export function Sizes() {
+  return (
+    <div className="flex items-center gap-4">
+      <Kbd size="sm">Esc</Kbd>
+      <Kbd size="md">Esc</Kbd>
+      <Kbd size="lg">Esc</Kbd>
+    </div>
+  );
+}
+```
+
+
+## Usage
+
+```tsx
+import Kbd from "./kbd";
+
+export function Example() {
+  return (
+    <div>
+      <Kbd>Esc</Kbd>
+      <span> to close, </span>
+      <Kbd>Ctrl</Kbd> + <Kbd>C</Kbd> to copy
+    </div>
+  );
+}
+```
+
+## Props
+
+<PropsTable
+  props={[
+    { name: "size", type: '"sm" | "md" | "lg"', default: '"md"', description: "Visual size of the keycap." },
+    { name: "className", type: "string", description: "Additional Tailwind classes to customize styling." },
+  ]}
+/>
+

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -100,6 +100,7 @@ export const navigation: NavigationItem[] = [
         badge: "New",
       },
       { label: "Curved Text", href: "/docs/curved-text", badge: "New" },
+      { label: "Kbd Text", href: "/docs/kbd", badge: "New" },
     ],
   },
   {


### PR DESCRIPTION
## Description
- Added `Kbd` component for displaying keyboard keys and shortcuts
- Docs page with:
  - Single top preview (Ctrl + C)
  - “Sizes” section (sm, md, lg) with live preview and code sample
- Added `PropsTable` for `Kbd` props
- Navigation updated under “Typography”

## Screenshots
- Preview (Ctrl + C):  
<img width="217" height="121" alt="Bildschirmfoto 2025-08-20 um 11 48 49" src="https://github.com/user-attachments/assets/b4aa16b5-66ee-4553-8793-0f6abd6d1402" />

- Sizes (sm/md/lg):  
<img width="229" height="129" alt="Bildschirmfoto 2025-08-20 um 11 48 56" src="https://github.com/user-attachments/assets/73a81fdb-4969-4b43-a4f3-4aa9f01704f5" />


## Functionality
- Semantic `<kbd>` element styled with Tailwind
- Sizes: `sm`, `md` (default), `lg`
- Compose shortcuts like `Ctrl + C`, `Cmd + Shift + P`

## Breaking changes
- None