### PR TITLE
fix: via.placeholder.com shut down in 2024 (now connection-refused)

### DIFF
--- a/src/app/docs/html-code/page.mdx
+++ b/src/app/docs/html-code/page.mdx
@@ -129,7 +129,7 @@ const complexHtml = `<body class="min-h-screen bg-gradient-to-br from-purple-900
   <div class="max-w-md mx-auto bg-white rounded-xl shadow-md overflow-hidden md:max-w-2xl">
     <div class="md:flex">
       <div class="md:shrink-0">
-        <img class="h-48 w-full object-cover md:h-full md:w-48" src="https://via.placeholder.com/300x200" alt="Modern building architecture">
+        <img class="h-48 w-full object-cover md:h-full md:w-48" src="https://placehold.co/300x200" alt="Modern building architecture">
       </div>
       <div class="p-8">
         <div class="uppercase tracking-wide text-sm text-indigo-500 font-semibold">Company retreats</div>


### PR DESCRIPTION
`src/app/docs/html-code/page.mdx` references `via.placeholder.com/*`. The service was shut down in 2024 and the DNS record no longer resolves.

---

#### Why this is needed

`via.placeholder.com` was shut down in 2024 and its DNS record no longer resolves — every request now hangs or returns a connection error. Any example that references it renders a broken-image icon (and any code that depends on a 200 from it silently breaks).

Verify in any shell:

```
curl -sI --max-time 3 https://via.placeholder.com/300x200 || echo "connection refused / DNS gone"
```

#### What this PR changes

Fixes the `<img>` in the HTML-code docs page so the modern-building-architecture example renders on the seraui docsite.

#### Replacement details

Docs-only. Identical dimensions (300×200) and preserved alt text.

#### Background

I'm tracking dead image-placeholder endpoints (`source.unsplash.com/*`, `via.placeholder.com/*`, `placekitten.com/*`) across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg is **not** a dependency of this PR — the diff uses the dependency-free canonical replacement (`placehold.co`, which accepts the same path shape as `via.placeholder.com`). If you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights dead-placeholder patterns in any landing page — useful for verifying the fix lands and for finding other places dead URLs slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.
