### PR TITLE
Add docs previous/next bottom navigation

### DIFF
--- a/src/components/site/doc-pagination.tsx
+++ b/src/components/site/doc-pagination.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { getAdjacentPages } from "@/lib/docs-navigation";
+import { cn } from "@/lib/utils";
+
+export function DocPagination() {
+  const pathname = usePathname();
+  const { previous, next } = getAdjacentPages(pathname);
+
+  if (!previous && !next) {
+    return null;
+  }
+
+  return (
+    <div className="mt-10 pt-6 border-t border-zinc-200 dark:border-zinc-800">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className={cn(!previous && "md:col-start-2")}>
+          {previous && (
+            <Link
+              href={previous.href}
+              className="group flex items-center gap-3 rounded-xl border border-zinc-200 dark:border-zinc-800 px-4 py-3 hover:bg-zinc-50 dark:hover:bg-zinc-900/40 transition-colors"
+            >
+              <ChevronLeft className="h-4 w-4 text-zinc-500 group-hover:-translate-x-0.5 transition-transform" />
+              <div className="flex flex-col">
+                <span className="text-xs text-zinc-500">Previous</span>
+                <span className="text-sm font-medium text-zinc-800 dark:text-zinc-100">
+                  {previous.label}
+                </span>
+              </div>
+            </Link>
+          )}
+        </div>
+
+        <div>
+          {next && (
+            <Link
+              href={next.href}
+              className="group flex items-center justify-end gap-3 rounded-xl border border-zinc-200 dark:border-zinc-800 px-4 py-3 hover:bg-zinc-50 dark:hover:bg-zinc-900/40 transition-colors"
+            >
+              <div className="flex flex-col items-end">
+                <span className="text-xs text-zinc-500">Next</span>
+                <span className="text-sm font-medium text-zinc-800 dark:text-zinc-100">
+                  {next.label}
+                </span>
+              </div>
+              <ChevronRight className="h-4 w-4 text-zinc-500 group-hover:translate-x-0.5 transition-transform" />
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/site/docs-layout-content.tsx
+++ b/src/components/site/docs-layout-content.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from "react";
 import Header from "@/components/site/header";
 import Sidebar from "@/components/site/sidebar";
 import { TableOfContents } from "@/components/site/table-of-contents";
+import { DocPagination } from "@/components/site/doc-pagination";
 import { useTOC } from "@/contexts/toc-context";
 
 export function DocsLayoutContent({ children }: { children: ReactNode }) {
@@ -20,6 +21,7 @@ export function DocsLayoutContent({ children }: { children: ReactNode }) {
           <div className="prose prose-zinc dark:prose-invert prose-h1:text-3xl prose-h1:font-semibold prose-h2:text-xl prose-h2:font-semibold prose-h2:mt-14 prose-h3:text-lg prose-h3:font-medium prose-h3:scroll-m-20 max-w-full">
             {children}
           </div>
+          <DocPagination />
         </main>
         {showTOC && <TableOfContents />}
       </div>

--- a/src/lib/docs-navigation.ts
+++ b/src/lib/docs-navigation.ts
@@ -1,0 +1,97 @@
+import { navigation } from "@/constants/navigation";
+import { components } from "@/scripts/components";
+
+export type DocPage = {
+  label: string;
+  href: string;
+};
+
+const extraDocSlugs = [
+  "faq",
+  "hide-toc-example",
+  "orbits",
+  "progress",
+  "radio-buttons",
+  "randomtextreveal",
+  "retro-style-form",
+  "verify-badge",
+  "video-gallery",
+];
+
+function toLabel(slug: string) {
+  return slug
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function normalizePath(path: string) {
+  if (path.endsWith("/") && path !== "/") {
+    return path.slice(0, -1);
+  }
+
+  return path;
+}
+
+function getNavigationPages(): DocPage[] {
+  const pages: DocPage[] = [];
+
+  navigation.forEach((section) => {
+    section.children.forEach((child) => {
+      pages.push({
+        label: child.label,
+        href: normalizePath(child.href),
+      });
+    });
+  });
+
+  return pages;
+}
+
+function getComponentPages(): DocPage[] {
+  return components.map((component) => ({
+    label: component.title || component.name,
+    href: `/docs/${component.name}`,
+  }));
+}
+
+function getExtraPages(): DocPage[] {
+  return extraDocSlugs.map((slug) => ({
+    label: toLabel(slug),
+    href: `/docs/${slug}`,
+  }));
+}
+
+export function getAllDocPages(): DocPage[] {
+  const map = new Map<string, DocPage>();
+
+  [...getNavigationPages(), ...getComponentPages(), ...getExtraPages()].forEach(
+    (page) => {
+      const href = normalizePath(page.href);
+
+      if (!map.has(href)) {
+        map.set(href, { ...page, href });
+      }
+    },
+  );
+
+  return Array.from(map.values());
+}
+
+export function getAdjacentPages(currentPath: string): {
+  previous: DocPage | null;
+  next: DocPage | null;
+} {
+  const pages = getAllDocPages();
+  const normalizedPath = normalizePath(currentPath);
+  const currentIndex = pages.findIndex((page) => page.href === normalizedPath);
+
+  if (currentIndex === -1) {
+    return { previous: null, next: null };
+  }
+
+  return {
+    previous: currentIndex > 0 ? pages[currentIndex - 1] : null,
+    next: currentIndex < pages.length - 1 ? pages[currentIndex + 1] : null,
+  };
+}


### PR DESCRIPTION
- add shared docs bottom pagination component with Previous/Next links
- compute adjacent docs pages from navigation + component registry + missing docs slugs
- render pagination from shared docs layout so all docs pages get consistent navigation

<img width="1922" height="955" alt="image" src="https://github.com/user-attachments/assets/7a221eec-7682-4d88-b9a1-774e928b4126" />
